### PR TITLE
Automatically add newline and prevent wrong file concats

### DIFF
--- a/gover/gover.go
+++ b/gover/gover.go
@@ -41,6 +41,11 @@ func Gover(root, out string) {
 
 		readBytes, readErr := ioutil.ReadFile(path)
 		if readErr == nil {
+			// Check if last character is new line, if not append it
+			if !bytes.HasSuffix(readBytes, []byte("\n")) {
+				readBytes = append(readBytes, []byte("\n")...)
+			}
+
 			readStr := string(readBytes)
 
 			re, _ := regexp.Compile("^mode: [a-z]+\n")


### PR DESCRIPTION
For some reason in my environment coverage files are missing `\n` character at the end. Running `gover` tool then produces invalid file.
