### PR TITLE
Correct the comment.

### DIFF
--- a/gover/gover.go
+++ b/gover/gover.go
@@ -28,7 +28,7 @@ then writes those files to `out`.
 If `root` is an invalid path or does not contain any relevant files, an empty
 string is written to `out`.
 
-If `out` already exists, this function appends the concatenation to `out`. If
+If `out` already exists, it is truncated first. If
 `out` does not exist, a new file is created with readwrite permissions (0666).
 */
 func Gover(root, out string) {


### PR DESCRIPTION
https://golang.org/pkg/io/ioutil/#WriteFile does truncate, not append.