### PR TITLE
Fix tests.

### DIFF
--- a/gover/gover_test.go
+++ b/gover/gover_test.go
@@ -7,13 +7,17 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 )
 
 func fixturesDir() string {
-	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-	return filepath.Join(dir, "_fixtures")
+	dir, err := filepath.Abs("_fixtures")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return dir
 }
 
 func readFile(path string) string {


### PR DESCRIPTION
go version go1.7.3 puts the test executable in a temporary directory such as
/tmp/go-build392344006/github.com/modocache/gover/gover/_test, which does not
contain the _fixtures directory, and as a result most of the tests fail.

However it does run the test with CWD set to the source directory, so it's
enough to just look at _fixtures in the current directory.